### PR TITLE
Add pyproject.toml & a github workflow for publishing pypi

### DIFF
--- a/.github/workflows/python-old.yml
+++ b/.github/workflows/python-old.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: python:2.7.18-buster
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+# When merged to master
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Build package
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install --upgrade pip
+          python3 -m pip install build
+          python3 -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/parser/elf.py
+++ b/parser/elf.py
@@ -102,7 +102,6 @@ def resolve_sym(fn, ip):
     elffile = find_elf_file(fn)
     if elffile is None:
         return "?", 0
-    global last_sym
 
     try:
         if fn not in symtables:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,61 @@
+[project]
+name = "pmu_tools"
+version = "2025.6.2"
+authors = [
+  { name="Andi Kleen", email="ak@linux.intel.com" },
+]
+description = "pmu tools is a collection of tools and libraries for profile collection and performance analysis on Intel CPUs on top of Linux perf. This uses performance counters in the CPU."
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+]
+license = "GPL-2.0-only"
+license-files = ["COPYING"]
+
+[project.urls]
+Homepage = "https://github.com/andikleen/pmu-tools/"
+Issues = "https://github.com/andikleen/pmu-tools/issues"
+
+[build-system]
+requires = [
+    "hatchling >= 1.26",
+]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/*",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["/"]
+
+
+[bumpver.file_patterns]
+"pyproject.toml" = [
+    'version = "{version}"',
+]
+
+[tool.bumpver]
+current_version = "2025.6.2"
+# Choose a PEP 440 compatible regex
+version_pattern = "YYYY.MM.INC0"
+tag_message = "{new_version}"
+tag_scope = "default"
+pre_commit_hook = ""
+post_commit_hook = ""
+commit = false
+tag = false
+push = false
+
+[tool.bumpver.file_patterns]
+"pyproject.toml" = [
+    'version = "{version}"',
+]
+"README.md" = [
+    "{version}",
+    "{pep440_version}",
+]

--- a/toplev.py
+++ b/toplev.py
@@ -4646,8 +4646,6 @@ def main(args, rest, feat, env, cpu):
     global KEEP_UNREF
     if len(runner_list) > 1 and isinstance(KEEP_UNREF, bool):
         KEEP_UNREF = True # for now -- dummy can get assigned to wrong runner
-    global INAME
-    global FUZZYINPUT
     if len(runner_list) > 1 and (INAME or FUZZYINPUT):
         sys.exit("INAME and FUZZYINPUT do not support hybrid")
     handle_more_options(args)


### PR DESCRIPTION
**Description**
I would like to use pmu-tools within my company, and to enable the use of ocperf.py, I need to package the tool as a Python wheel for easy installation and distribution.

This PR introduces the necessary code and configuration to allow packaging pmu-tools into a wheel.

Note: This package is not yet fully usable out of the box, as it does not currently install the existing scripts into the user’s PATH. I plan to address that in a follow-up PR.

**Important Decisions**
Versioning Scheme: CalVer. I noticed some git tags have rYYYY... format so I followed a similar scheme

**Test Plan**
Published one release: https://pypi.org/project/pmu-tools/ 